### PR TITLE
Optimize hero: disable mouse react, fix mobile layout

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -40,7 +40,7 @@ export default function Hero({ data }: HeroProps) {
         </div>
       )}
 
-      <div className="p-8 -mt-32">
+      <div className="px-0 py-6 lg:p-8 lg:-mt-32">
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}

--- a/components/HeroBackground.tsx
+++ b/components/HeroBackground.tsx
@@ -3,5 +3,5 @@
 import FaultyTerminal from '@/components/Backgrounds/FaultyTerminal';
 
 export default function HeroBackground() {
-  return <FaultyTerminal className="opacity-30 z-0" />;
+  return <FaultyTerminal className="opacity-30 z-0" mouseReact={false} />;
 }


### PR DESCRIPTION
## Summary
- Disable `mouseReact` on `FaultyTerminal` to skip per-frame mouse damping and remove the document-level `mousemove` listener
- Fix hero content div padding on mobile — removes inner horizontal padding since outer wrapper already provides `px-4`
- Restrict avatar overlap effect (`-mt-32`) to desktop only via `lg:` breakpoint, so the profile image flows cleanly above text on mobile