### PR TITLE
Add hero background media/overlay controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,7 +41,7 @@ export default async function Home() {
           >
             {index === 0 && layoutBlock.heroSection && (
               <>
-                <HeroBackground />
+                <HeroBackground background={layoutBlock.heroSection?.background} />
                 <div className="absolute inset-0 bg-linear-to-b from-base/40 via-transparent to-transparent pointer-events-none z-10" />
                 <div className="h-full flex items-center justify-start relative z-20 pointer-events-none">
                   <div className="pointer-events-auto relative z-20 px-4 lg:w-4/5 lg:mx-auto lg:p-8">

--- a/components/CertificationsSection.tsx
+++ b/components/CertificationsSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
 import { CalendarIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-import { urlFor } from '@/lib/sanity/image';
+import MediaRenderer from '@/components/MediaRenderer';
 import { useMouseGlow } from '@/hooks/useMouseGlow';
 import type { CertificationsSection as CertificationsSectionType, Certification } from '@/lib/cms/types';
 
@@ -47,10 +47,11 @@ function CertificationCard({ certification, index, isDesktop }: { certification:
         <div className="relative z-10 space-y-4 flex-1 flex flex-col">
           {certification.image && (
             <div className="relative overflow-hidden rounded-xl w-full aspect-video">
-              <img
-                src={urlFor(certification.image).width(800).quality(80).auto('format').url()}
+              <MediaRenderer
+                media={{ mediaType: 'image', image: certification.image }}
                 alt={certification.title}
                 className="w-full h-full object-cover lg:group-hover:scale-105 transition-transform duration-300"
+                quality={80}
               />
               <div className="absolute inset-0 bg-linear-to-t from-black/20 to-transparent opacity-0 lg:group-hover:opacity-100 transition-opacity duration-300" />
             </div>

--- a/components/HeroBackground.tsx
+++ b/components/HeroBackground.tsx
@@ -1,7 +1,57 @@
 'use client';
 
 import FaultyTerminal from '@/components/Backgrounds/FaultyTerminal';
+import MediaRenderer from '@/components/MediaRenderer';
 
-export default function HeroBackground() {
-  return <FaultyTerminal className="opacity-30 z-0" mouseReact={false} />;
+const overlayClass: Record<'dark' | 'darker', string> = {
+  dark: 'absolute inset-0 bg-black/50 z-[1]',
+  darker: 'absolute inset-0 bg-black/80 z-[1]',
+};
+
+interface HeroBackgroundProps {
+  background?: {
+    overlay?: 'none' | 'dark' | 'darker';
+    type?: 'faultyTerminal' | 'image' | 'video';
+    image?: { asset?: { _ref?: string }; hotspot?: unknown; crop?: unknown };
+    videoUrl?: string;
+  };
+}
+
+export default function HeroBackground({ background }: HeroBackgroundProps) {
+  const overlay = background?.overlay && background.overlay !== 'none'
+    ? <div className={overlayClass[background.overlay]} aria-hidden="true" />
+    : null;
+
+  if (!background?.type || background.type === 'faultyTerminal') {
+    return (
+      <>
+        <FaultyTerminal className="opacity-30 z-0" mouseReact={false} />
+        {overlay}
+      </>
+    );
+  }
+
+  const media =
+    background.type === 'image' && background.image
+      ? { mediaType: 'image' as const, image: background.image }
+      : background.type === 'video' && background.videoUrl
+        ? { mediaType: 'video' as const, videoUrl: background.videoUrl }
+        : null;
+
+  if (media) {
+    return (
+      <>
+        <MediaRenderer
+          media={media}
+          className="absolute inset-0 w-full h-full object-cover z-0"
+          width={1920}
+          quality={80}
+        />
+        {overlay}
+      </>
+    );
+  }
+
+  // No background selected or missing asset — black via parent's bg-base class
+  return null;
 }

--- a/components/MediaRenderer.tsx
+++ b/components/MediaRenderer.tsx
@@ -1,0 +1,44 @@
+import { urlFor } from '@/lib/sanity/image';
+import type { SanityMedia } from '@/lib/cms/types';
+
+interface MediaRendererProps {
+  media: SanityMedia;
+  alt?: string;
+  className?: string;
+  width?: number;
+  quality?: number;
+}
+
+export default function MediaRenderer({
+  media,
+  alt = '',
+  className = '',
+  width = 800,
+  quality = 75,
+}: MediaRendererProps) {
+  if (media.mediaType === 'video' && media.videoUrl) {
+    return (
+      <video
+        className={className}
+        autoPlay
+        muted
+        loop
+        playsInline
+      >
+        <source src={media.videoUrl} />
+      </video>
+    );
+  }
+
+  if (media.image?.asset?._ref) {
+    return (
+      <img
+        src={urlFor(media.image).width(width).quality(quality).auto('format').url()}
+        alt={alt}
+        className={className}
+      />
+    );
+  }
+
+  return null;
+}

--- a/components/ProjectsSection.tsx
+++ b/components/ProjectsSection.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
-import { urlFor } from '@/lib/sanity/image';
+import MediaRenderer from '@/components/MediaRenderer';
 import {
   ArrowTopRightOnSquareIcon, CodeBracketIcon, EyeIcon,
   ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon
@@ -50,8 +50,8 @@ function ProjectSlide({
         <div className="relative">
           {project.image ? (
             <div className="relative overflow-hidden rounded-xl group w-full h-40 lg:aspect-square lg:h-auto">
-              <img
-                src={urlFor(project.image).width(800).quality(75).auto('format').url()}
+              <MediaRenderer
+                media={{ mediaType: 'image', image: project.image }}
                 alt={project.title}
                 className="w-full h-full object-cover lg:group-hover:scale-105 transition-transform duration-300"
               />

--- a/lib/cms/types/certificationsSection.ts
+++ b/lib/cms/types/certificationsSection.ts
@@ -8,11 +8,7 @@ export interface Certification {
   credentialId?: string;
   credentialUrl?: string;
   description?: string;
-  image?: {
-    asset?: { _ref?: string };
-    hotspot?: unknown;
-    crop?: unknown;
-  };
+  image?: { asset?: { _ref?: string }; hotspot?: unknown; crop?: unknown };
 }
 
 export interface CertificationsSection {

--- a/lib/cms/types/index.ts
+++ b/lib/cms/types/index.ts
@@ -1,3 +1,4 @@
+export * from './media';
 export * from './layoutBlock';
 export * from './aboutSection';
 export * from './projectsSection';

--- a/lib/cms/types/layoutBlock.ts
+++ b/lib/cms/types/layoutBlock.ts
@@ -11,6 +11,12 @@ export interface HeroSection {
   };
   cta1?: { text: string; url: string; isExternal: boolean };
   cta2?: { text: string; url: string; isExternal: boolean; email?: string };
+  background?: {
+    overlay?: 'none' | 'dark' | 'darker';
+    type?: 'faultyTerminal' | 'image' | 'video';
+    image?: { asset?: { _ref?: string }; hotspot?: unknown; crop?: unknown };
+    videoUrl?: string;
+  };
 }
 
 export interface LayoutBlock {

--- a/lib/cms/types/media.ts
+++ b/lib/cms/types/media.ts
@@ -1,0 +1,10 @@
+export interface SanityMedia {
+  mediaType?: 'image' | 'video';
+  image?: {
+    asset?: { _ref?: string };
+    hotspot?: unknown;
+    crop?: unknown;
+  };
+  /** Resolved video URL (from GROQ `video.asset->url` projection) */
+  videoUrl?: string;
+}

--- a/lib/cms/types/projectsSection.ts
+++ b/lib/cms/types/projectsSection.ts
@@ -10,11 +10,7 @@ export interface Project {
   title: string;
   slug: { current: string };
   description: string;
-  image?: {
-    asset?: { _ref?: string };
-    hotspot?: unknown;
-    crop?: unknown;
-  };
+  image?: { asset?: { _ref?: string }; hotspot?: unknown; crop?: unknown };
   techStack?: string[];
   challenges?: string[];
   demoUrl?: string;

--- a/lib/sanity/queries.ts
+++ b/lib/sanity/queries.ts
@@ -18,7 +18,13 @@ export async function getHomePage() {
       ...,
       heroSection{
         ...,
-        profileImage{ asset, hotspot, crop }
+        profileImage{ asset, hotspot, crop },
+        background{
+          overlay,
+          type,
+          image{ asset, hotspot, crop },
+          "videoUrl": video.asset->url
+        }
       },
       projectsSection{
         headline,

--- a/sanity/schemaTypes/heroSection.ts
+++ b/sanity/schemaTypes/heroSection.ts
@@ -101,6 +101,57 @@ export default {
       options: {
         hotspot: true
       }
+    },
+    {
+      name: 'background',
+      title: 'Hero Background',
+      description: 'Choose what appears behind the hero content',
+      type: 'object',
+      fields: [
+        {
+          name: 'overlay',
+          title: 'Overlay',
+          description: 'Darkens the background to improve text readability',
+          type: 'string',
+          options: {
+            list: [
+              { title: 'None', value: 'none' },
+              { title: 'Dark (50%)', value: 'dark' },
+              { title: 'Darker (80%)', value: 'darker' },
+            ],
+            layout: 'radio',
+          },
+          initialValue: 'none',
+        },
+        {
+          name: 'type',
+          title: 'Background Type',
+          type: 'string',
+          options: {
+            list: [
+              { title: 'Faulty Terminal (WebGL animation)', value: 'faultyTerminal' },
+              { title: 'Image', value: 'image' },
+              { title: 'Video', value: 'video' },
+            ],
+            layout: 'radio',
+          },
+          initialValue: 'faultyTerminal',
+        },
+        {
+          name: 'image',
+          title: 'Background Image',
+          type: 'image',
+          options: { hotspot: true },
+          hidden: ({ parent }: any) => parent?.type !== 'image',
+        },
+        {
+          name: 'video',
+          title: 'Background Video',
+          type: 'file',
+          options: { accept: 'video/*' },
+          hidden: ({ parent }: any) => parent?.type !== 'video',
+        },
+      ],
     }
   ],
   preview: {

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -16,15 +16,17 @@ import contactSection from './contactSection';
 import page from './page';
 import careerEntry from './careerEntry';
 import technologyStack from './technologyStack';
+import media from './media';
 
 export const schemaTypes = [
-  project, 
-  commendation, 
-  skill, 
-  certification, 
-  profile, 
-  navbar, 
-  footer, 
+  media,
+  project,
+  commendation,
+  skill,
+  certification,
+  profile,
+  navbar,
+  footer,
   layoutBlock,
   heroSection,
   aboutSection,

--- a/sanity/schemaTypes/media.ts
+++ b/sanity/schemaTypes/media.ts
@@ -1,0 +1,34 @@
+export default {
+  name: 'media',
+  title: 'Media',
+  type: 'object',
+  fields: [
+    {
+      name: 'mediaType',
+      title: 'Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Image', value: 'image' },
+          { title: 'Video', value: 'video' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'image',
+    },
+    {
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: { hotspot: true },
+      hidden: ({ parent }: any) => parent?.mediaType !== 'image',
+    },
+    {
+      name: 'video',
+      title: 'Video',
+      type: 'file',
+      options: { accept: 'video/*' },
+      hidden: ({ parent }: any) => parent?.mediaType !== 'video',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Adds image, video, and overlay (none / dark 50% / darker 80%) controls to the hero background in Sanity Studio
- Flattens the hero background schema from a nested `media` object to direct `image` and `video` fields
- Simplifies project and certification schemas to a plain `image` field (video not needed for those types)
- Introduces `MediaRenderer` component and `SanityMedia` type as shared rendering primitives, replacing inline `urlFor()` calls