### PR TITLE
Migrate to next/font with Outfit + Plus Jakarta Sans

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,24 +50,17 @@
 }
 
 @layer base {
-  :root {
-    font-family: 'Inter', 'Roboto', ui-sans-serif, system-ui, sans-serif;
-  }
-
   html {
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
   }
 
   body {
+    @apply font-body text-text-primary bg-base antialiased;
+    line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     backface-visibility: hidden;
-  }
-
-  body {
-    @apply font-body text-text-primary bg-base antialiased;
-    line-height: 1.7;
   }
 
   h1, h2, h3, h4, h5, h6 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,17 @@
 import type { Metadata } from 'next';
+import { Outfit, Plus_Jakarta_Sans } from 'next/font/google';
 import './globals.css';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+
+const outfit = Outfit({
+  subsets: ['latin'],
+  variable: '--font-heading',
+});
+
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-body',
+});
 
 export const metadata: Metadata = {
   title: 'Van Ian Ignacio | QA Portfolio',
@@ -13,15 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className={`dark ${outfit.variable} ${plusJakartaSans.variable}`}>
       <head>
         <link rel="icon" href="/favicon-vip.ico" sizes="any" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700;800&family=Montserrat:wght@600;700;800&display=swap"
-          rel="stylesheet"
-        />
       </head>
       <body className="bg-base text-text-primary">
         {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,8 +42,8 @@ module.exports = {
         },
       },
       fontFamily: {
-        heading: ['Poppins', 'Montserrat', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        body: ['Inter', 'Roboto', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        heading: ['var(--font-heading)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        body: ['var(--font-body)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
       boxShadow: {
         'soft': '0 6px 24px rgba(0,0,0,0.25)',


### PR DESCRIPTION
## Summary
- Replace Google Fonts CDN `<link>` tags with `next/font/google` for self-hosted, zero-layout-shift font loading
- Swap heading font Poppins → Outfit (geometric, modern) and body font Inter → Plus Jakarta Sans (more personality)
- Fonts expose CSS variables (`--font-heading`, `--font-body`) consumed by Tailwind `font-heading`/`font-body` utilities — no component changes needed
- Remove redundant `:root { font-family }` and consolidate duplicate `body` rules in `globals.css`