### PR TITLE
Redesign projects carousel with card-swap and fixed layout

### DIFF
--- a/components/ProjectsSection.tsx
+++ b/components/ProjectsSection.tsx
@@ -12,6 +12,8 @@ import { useMouseGlow } from '@/hooks/useMouseGlow';
 import { useIsDesktop } from '@/hooks/useIsDesktop';
 import type { ProjectsSection as ProjectsSectionType, Project } from '@/lib/cms/types';
 
+const swiftEase: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
 const slideVariants = {
   enter: (direction: number) => ({
     x: direction > 0 ? 40 : -40,
@@ -20,12 +22,12 @@ const slideVariants = {
   center: {
     x: 0,
     opacity: 1,
-    transition: { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
+    transition: { duration: 0.35, ease: swiftEase },
   },
   exit: (direction: number) => ({
     x: direction > 0 ? -40 : 40,
     opacity: 0,
-    transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] },
+    transition: { duration: 0.25, ease: swiftEase },
   }),
 };
 


### PR DESCRIPTION
## Summary
- Replace translate-strip carousel with AnimatePresence card-swap — each project is an independent card with directional slide+fade transition
- Flush image layout removes inner card nesting; image fills left column edge-to-edge
- Fixed card height (`h-[640px] lg:h-[560px]`) with `p-10` padding ensures CTA always sits 40px from card edge via `mt-auto`
- Dot indicators replaced with `01 / 03` counter; arrows flank card on desktop, appear below counter on mobile
- Description clamped to 4 lines with "Read more →" link to `/projects` (404s until projects page is built)